### PR TITLE
Make `literal!` no longer require `unsafe`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - { build: macos,    os: macos-latest, rust: stable }
           - { build: win-msvc, os: windows-2019, rust: stable }
           - { build: win-gnu,  os: windows-2019, rust: stable-x86_64-gnu }
-          - { build: msrv,     os: ubuntu-latest, rust: '1.43.0' }
+          - { build: msrv,     os: ubuntu-latest, rust: '1.45.0' }
           - { build: beta,     os: ubuntu-latest, rust: beta }
           - { build: nightly,  os: ubuntu-latest, rust: nightly }
           - { build: linux32,  os: ubuntu-latest, rust: stable, target: i686-unknown-linux-gnu }
@@ -238,4 +238,3 @@ jobs:
           args: --all-features
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
-

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -18,7 +18,7 @@ use alloc::string::String;
 ///   structure lightweight or need to do some FFI stuff with it.
 ///
 /// - It's possible to create a const `arcstr` from a literal via the
-///   [`literal_arcstr!`][crate::literal_arcstr] macro.
+///   [`literal!`][`crate::literal`] macro.
 ///
 ///   These are zero cost, take no heap allocation, and don't even need to
 ///   perform atomic reads/writes when being cloned or dropped (or at any other
@@ -86,12 +86,12 @@ use alloc::string::String;
 /// The big unique feature of `ArcStr`, aside from its charming personality, is
 /// the ability to create static/const `ArcStr`s. This is kind of annoying,
 /// since it requires unsafe, but the safety requirement is just UTF-8 validity
-/// of the provided byte string. (See [the macro](crate::literal_arcstr) docs
+/// of the provided byte string. (See [the macro](crate::literal) docs
 /// for details.
 ///
 /// ```
-/// # use arcstr::{ArcStr, literal_arcstr};
-/// const WOW: ArcStr = unsafe { literal_arcstr!(b"cool robot!") };
+/// # use arcstr::{ArcStr, literal};
+/// const WOW: ArcStr = unsafe { literal!("cool robot!") };
 /// assert_eq!(WOW, "cool robot!");
 /// ```
 #[repr(transparent)]
@@ -254,7 +254,7 @@ impl ArcStr {
     ///
     /// Caveat: `const`s aren't guaranteed to only occur in an executable a
     /// single time, and so this may be non-deterministic for `ArcStr` defined
-    /// in a `const` with [`literal_arcstr!`][crate::literal_arcstr], unless one
+    /// in a `const` with [`literal!`][crate::literal], unless one
     /// was created by a `clone()` on the other.
     ///
     /// # Examples
@@ -268,7 +268,7 @@ impl ArcStr {
     /// assert!(ArcStr::ptr_eq(&foobar, &same_foobar));
     /// assert!(!ArcStr::ptr_eq(&foobar, &other_foobar));
     ///
-    /// const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = unsafe { arcstr::literal_arcstr!(b"foobar") };
+    /// const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = unsafe { arcstr::literal!("foobar") };
     /// let strange_new_foobar = YET_AGAIN_A_DIFFERENT_FOOBAR.clone();
     /// let wild_blue_foobar = strange_new_foobar.clone();
     /// assert!(ArcStr::ptr_eq(&strange_new_foobar, &wild_blue_foobar));
@@ -280,7 +280,7 @@ impl ArcStr {
 
     /// Returns the number of references that exist to this `ArcStr`. If this is
     /// a static `ArcStr` (For example, one from
-    /// [`literal_arcstr!`][crate::literal_arcstr]), returns `None`.
+    /// [`literal!`][crate::literal]), returns `None`.
     ///
     /// Despite the difference in return type, this is named to match the method
     /// from the stdlib's Arc:
@@ -314,9 +314,9 @@ impl ArcStr {
     ///
     /// ### Static ArcStr
     /// ```
-    /// # use arcstr::{ArcStr, literal_arcstr};
+    /// # use arcstr::{ArcStr, literal};
     /// // Safety: This is safe because it consists of valid UTF-8.
-    /// let baz = unsafe { literal_arcstr!(b"baz") };
+    /// let baz = unsafe { literal!("baz") };
     /// assert_eq!(None, ArcStr::strong_count(&baz));
     /// // Similarly:
     /// assert_eq!(None, ArcStr::strong_count(&ArcStr::default()));
@@ -332,7 +332,7 @@ impl ArcStr {
     }
 
     /// Returns true if `this` is a "static" ArcStr. For example, if it was
-    /// created from a call to [`literal_arcstr!`][crate::literal_arcstr]),
+    /// created from a call to [`literal!`][crate::literal]),
     /// returned by `ArcStr::new`, etc.
     ///
     /// Static `ArcStr`s can be converted to `&'static str` for free using
@@ -343,10 +343,10 @@ impl ArcStr {
     ///
     /// ```
     /// # use arcstr::ArcStr;
-    /// const STATIC: ArcStr = unsafe { arcstr::literal_arcstr!(b"Electricity!") };
+    /// const STATIC: ArcStr = unsafe { arcstr::literal!("Electricity!") };
     /// assert!(ArcStr::is_static(&STATIC));
     ///
-    /// let still_static = unsafe { arcstr::literal_arcstr!(b"Shocking!") };
+    /// let still_static = unsafe { arcstr::literal!("Shocking!") };
     /// assert!(ArcStr::is_static(&still_static));
     /// assert!(ArcStr::is_static(&still_static.clone()), "Cloned statics are still static");
     ///
@@ -359,7 +359,7 @@ impl ArcStr {
     }
 
     /// Returns true if `this` is a "static" ArcStr. For example, if it was
-    /// created from a call to [`literal_arcstr!`][crate::literal_arcstr]),
+    /// created from a call to [`literal!`][crate::literal]),
     /// returned by `ArcStr::new`, etc.
     ///
     /// Static `ArcStr`s can be converted to `&'static str` for free using
@@ -370,11 +370,11 @@ impl ArcStr {
     ///
     /// ```
     /// # use arcstr::ArcStr;
-    /// const STATIC: ArcStr = unsafe { arcstr::literal_arcstr!(b"Electricity!") };
+    /// const STATIC: ArcStr = unsafe { arcstr::literal!("Electricity!") };
     /// assert_eq!(ArcStr::as_static(&STATIC), Some("Electricity!"));
     ///
-    /// // Note that they don't have to be consts, just made using `literal_arcstr!`:
-    /// let still_static = unsafe { arcstr::literal_arcstr!(b"Shocking!") };
+    /// // Note that they don't have to be consts, just made using `literal!`:
+    /// let still_static = unsafe { arcstr::literal!("Shocking!") };
     /// assert_eq!(ArcStr::as_static(&still_static), Some("Shocking!"));
     /// // Cloning a static still produces a static.
     /// assert_eq!(ArcStr::as_static(&still_static.clone()), Some("Shocking!"));
@@ -393,7 +393,7 @@ impl ArcStr {
         }
     }
 
-    // Not public API. Exists so the literal_arcstr macro can call it.
+    // Not public API. Exists so the literal macro can call it.
     #[inline]
     #[doc(hidden)]
     pub const unsafe fn new_static<B>(ptr: &'static StaticArcStrInner<B>) -> Self {

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -91,7 +91,7 @@ use alloc::string::String;
 ///
 /// ```
 /// # use arcstr::{ArcStr, literal};
-/// const WOW: ArcStr = unsafe { literal!("cool robot!") };
+/// const WOW: ArcStr = literal!("cool robot!");
 /// assert_eq!(WOW, "cool robot!");
 /// ```
 #[repr(transparent)]
@@ -268,7 +268,7 @@ impl ArcStr {
     /// assert!(ArcStr::ptr_eq(&foobar, &same_foobar));
     /// assert!(!ArcStr::ptr_eq(&foobar, &other_foobar));
     ///
-    /// const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = unsafe { arcstr::literal!("foobar") };
+    /// const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = arcstr::literal!("foobar");
     /// let strange_new_foobar = YET_AGAIN_A_DIFFERENT_FOOBAR.clone();
     /// let wild_blue_foobar = strange_new_foobar.clone();
     /// assert!(ArcStr::ptr_eq(&strange_new_foobar, &wild_blue_foobar));
@@ -316,7 +316,7 @@ impl ArcStr {
     /// ```
     /// # use arcstr::{ArcStr, literal};
     /// // Safety: This is safe because it consists of valid UTF-8.
-    /// let baz = unsafe { literal!("baz") };
+    /// let baz = literal!("baz");
     /// assert_eq!(None, ArcStr::strong_count(&baz));
     /// // Similarly:
     /// assert_eq!(None, ArcStr::strong_count(&ArcStr::default()));
@@ -343,10 +343,10 @@ impl ArcStr {
     ///
     /// ```
     /// # use arcstr::ArcStr;
-    /// const STATIC: ArcStr = unsafe { arcstr::literal!("Electricity!") };
+    /// const STATIC: ArcStr = arcstr::literal!("Electricity!");
     /// assert!(ArcStr::is_static(&STATIC));
     ///
-    /// let still_static = unsafe { arcstr::literal!("Shocking!") };
+    /// let still_static = arcstr::literal!("Shocking!");
     /// assert!(ArcStr::is_static(&still_static));
     /// assert!(ArcStr::is_static(&still_static.clone()), "Cloned statics are still static");
     ///
@@ -370,11 +370,11 @@ impl ArcStr {
     ///
     /// ```
     /// # use arcstr::ArcStr;
-    /// const STATIC: ArcStr = unsafe { arcstr::literal!("Electricity!") };
+    /// const STATIC: ArcStr = arcstr::literal!("Electricity!");
     /// assert_eq!(ArcStr::as_static(&STATIC), Some("Electricity!"));
     ///
     /// // Note that they don't have to be consts, just made using `literal!`:
-    /// let still_static = unsafe { arcstr::literal!("Shocking!") };
+    /// let still_static = arcstr::literal!("Shocking!");
     /// assert_eq!(ArcStr::as_static(&still_static), Some("Shocking!"));
     /// // Cloning a static still produces a static.
     /// assert_eq!(ArcStr::as_static(&still_static.clone()), Some("Shocking!"));

--- a/src/proc_macros/Cargo.toml
+++ b/src/proc_macros/Cargo.toml
@@ -1,7 +1,14 @@
+[lib]
+proc-macro = true
+path = "mod.rs"
+
 [package]
-name = "arcstr"
+name = "arcstr-proc_macros"
 version = "0.1.0"  # keep in sync with src/proc_macros/Cargo.toml
-authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
+authors = [
+    "Thom Chiovoloni <chiovolonit@gmail.com>",
+    "Daniel Henry-Mantilla <daniel.henry.mantilla@gmail.com",
+]
 edition = "2018"
 description = "A better reference-counted string type"
 license = "Apache-2.0 OR MIT"
@@ -11,25 +18,3 @@ categories = ["concurrency", "memory-management", "data-structures", "no-std", "
 repository = "https://github.com/thomcc/arcstr"
 documentation = "https://docs.rs/arcstr"
 homepage = "https://github.com/thomcc/arcstr"
-
-[features]
-std = []
-default = []
-
-[dependencies]
-memoffset = "0.5"
-serde = { version = "1", default-features = false, optional = true }
-
-[dependencies.proc_macros]
-version = "0.1.0"
-path = "src/proc_macros"
-package = "arcstr-proc_macros"
-
-[dev-dependencies]
-serde_test = {version = "1", default-features=false}
-
-[target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.3" }
-
-[workspace]
-members = ["src/proc_macros"]

--- a/src/proc_macros/helpers.rs
+++ b/src/proc_macros/helpers.rs
@@ -1,0 +1,19 @@
+use ::proc_macro::{TokenTree as TT, *};
+
+pub(super) fn compile_error(err_msg: &'_ str, span: Span) -> TokenStream {
+    macro_rules! spanned {
+        ($expr:expr) => {{
+            let mut it = $expr;
+            it.set_span(span);
+            it
+        }};
+    }
+    <TokenStream as ::std::iter::FromIterator<_>>::from_iter(vec![
+        TT::Ident(Ident::new("compile_error", span)),
+        TT::Punct(spanned!(Punct::new('!', Spacing::Alone))),
+        TT::Group(spanned!(Group::new(
+            Delimiter::Brace,
+            TT::Literal(spanned!(Literal::string(err_msg))).into(),
+        ))),
+    ])
+}

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -33,8 +33,6 @@ pub fn byte_lit(mut input: TokenStream) -> TokenStream {
             let value: &str = &s[1..(s.len() - 1)]; // string literal contents
             TT::Literal(Literal::byte_string(value.as_bytes())).into()
         }
-        (Some(invalid_tt), _) => {
-            compile_error("Expected a string literal", invalid_tt.span())
-        }
+        (Some(invalid_tt), _) => compile_error("Expected a string literal", invalid_tt.span()),
     }
 }

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -1,0 +1,40 @@
+extern crate proc_macro;
+
+use self::helpers::compile_error;
+use ::proc_macro::{TokenTree as TT, *};
+
+mod helpers;
+
+#[proc_macro]
+pub fn byte_lit(mut input: TokenStream) -> TokenStream {
+    let (first, snd) = loop {
+        let mut iter = input.into_iter();
+        let first = iter.next();
+        match first {
+            Some(TT::Group(g)) if g.delimiter() == Delimiter::None => {
+                input = g.stream();
+                continue;
+            }
+            _ => {}
+        }
+        break (first, iter.next());
+    };
+    let mut storage = None;
+    match (first, snd) {
+        (None, _) => compile_error("Missing parameter", Span::call_site()),
+        (_, Some(unexpected)) => compile_error("Unexpected token", unexpected.span()),
+        (Some(TT::Literal(lit)), _)
+            if {
+                let s = storage.get_or_insert(lit.to_string());
+                s.starts_with('"') && s.ends_with('"') // is a string literal
+            } =>
+        {
+            let ref s = storage.unwrap();
+            let value: &str = &s[1..(s.len() - 1)]; // string literal contents
+            TT::Literal(Literal::byte_string(value.as_bytes())).into()
+        }
+        (Some(invalid_tt), _) => {
+            compile_error("Expected a string literal", invalid_tt.span())
+        }
+    }
+}

--- a/tests/arc_str.rs
+++ b/tests/arc_str.rs
@@ -87,7 +87,7 @@ fn smoke_test_clone() {
     for _ in 0..count {
         drop(vec![ArcStr::from("foobar"); count]);
         drop(vec![ArcStr::from("baz quux"); count]);
-        let lit = unsafe { arcstr::literal_arcstr!(b"test 999") };
+        let lit = arcstr::literal!("test 999");
         drop(vec![lit; count]);
     }
     drop(vec![ArcStr::default(); count]);
@@ -196,7 +196,7 @@ fn test_strong_count() {
     assert_eq!(Some(2), ArcStr::strong_count(&foobar));
     assert_eq!(Some(2), ArcStr::strong_count(&also_foobar));
 
-    let baz = unsafe { arcstr::literal_arcstr!(b"baz") };
+    let baz = arcstr::literal!("baz");
     assert_eq!(None, ArcStr::strong_count(&baz));
     assert_eq!(None, ArcStr::strong_count(&ArcStr::default()));
 }
@@ -209,14 +209,14 @@ fn test_ptr_eq() {
     assert!(ArcStr::ptr_eq(&foobar, &same_foobar));
     assert!(!ArcStr::ptr_eq(&foobar, &other_foobar));
 
-    const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = unsafe { arcstr::literal_arcstr!(b"foobar") };
+    const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = arcstr::literal!("foobar");
     let strange_new_foobar = YET_AGAIN_A_DIFFERENT_FOOBAR.clone();
     let wild_blue_foobar = strange_new_foobar.clone();
     assert!(ArcStr::ptr_eq(&strange_new_foobar, &wild_blue_foobar));
 }
 #[test]
 fn test_statics() {
-    const STATIC: ArcStr = unsafe { arcstr::literal_arcstr!(b"Electricity!") };
+    const STATIC: ArcStr = arcstr::literal!("Electricity!");
     assert!(ArcStr::is_static(&STATIC));
     assert_eq!(ArcStr::as_static(&STATIC), Some("Electricity!"));
 
@@ -224,7 +224,7 @@ fn test_statics() {
     assert_eq!(ArcStr::as_static(&ArcStr::new()), Some(""));
     let st = {
         // Note that they don't have to be consts, just made using `literal_arcstr!`:
-        let still_static = unsafe { arcstr::literal_arcstr!(b"Shocking!") };
+        let still_static = arcstr::literal!("Shocking!");
         assert!(ArcStr::is_static(&still_static));
         assert_eq!(ArcStr::as_static(&still_static), Some("Shocking!"));
         assert_eq!(ArcStr::as_static(&still_static.clone()), Some("Shocking!"));
@@ -243,13 +243,14 @@ fn test_statics() {
 }
 
 #[test]
+#[ignore]
 fn test_static_arcstr_include_bytes() {
-    const APACHE: ArcStr = unsafe { arcstr::literal_arcstr!(include_bytes!("../LICENSE-APACHE")) };
-    assert!(APACHE.len() > 10000);
-    assert!(APACHE.trim_start().starts_with("Apache License"));
-    assert!(APACHE
-        .trim_end()
-        .ends_with("limitations under the License."));
+    // const APACHE: ArcStr = arcstr::literal!(include_bytes!("../LICENSE-APACHE"));
+    // assert!(APACHE.len() > 10000);
+    // assert!(APACHE.trim_start().starts_with("Apache License"));
+    // assert!(APACHE
+    //     .trim_end()
+    //     .ends_with("limitations under the License."));
 }
 
 #[test]
@@ -306,7 +307,7 @@ fn test_froms_more() {
     assert!(matches!(cow, Some(Cow::Owned(_))));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
-    let st = unsafe { arcstr::literal_arcstr!(b"static should borrow") };
+    let st = arcstr::literal!("static should borrow");
     {
         let cow: Option<Cow<'_, str>> = Some(st.clone()).map(Cow::from);
         assert!(matches!(cow, Some(Cow::Borrowed(_))));


### PR DESCRIPTION
This is achieved by making the macro consume a string literal rather than a byte string literal.
The issue being, we need a sized pointee to construct the static `ArcStr`.
For that, dereferencing the equivalent byte string literal solves the issue.

Saldy, there is no built-in way to convert a string literal into a byte string literal, but it is something a procedural macro can easily do, with **no dependencies whatsoever**.

Thus, this PR:

  - implements that procedural macro and its usage,

  - renames the macro to the more friendly `literal!` (based on the docs);

  - adapts the testing code accordingly;

  - such change **bumps the MSRV to 1.45.0** (or otherwise the proc-macro-hack dependency needs to be pulled; know that it is lightweight)

  - such change makes the macro **incompatible with the `include_***!` family of macros**;

      - The associated test has been commented out and `#[ignore]`-annotated,
        @thomcc you decide how do we handle this.