### PR TITLE
Implement the "good" version of the `arcstr::literal!` macro.

### DIFF
--- a/tests/arc_str.rs
+++ b/tests/arc_str.rs
@@ -87,7 +87,7 @@ fn smoke_test_clone() {
     for _ in 0..count {
         drop(vec![ArcStr::from("foobar"); count]);
         drop(vec![ArcStr::from("baz quux"); count]);
-        let lit = unsafe { arcstr::literal_arcstr!(b"test 999") };
+        let lit = { arcstr::literal!("test 999") };
         drop(vec![lit; count]);
     }
     drop(vec![ArcStr::default(); count]);
@@ -196,7 +196,7 @@ fn test_strong_count() {
     assert_eq!(Some(2), ArcStr::strong_count(&foobar));
     assert_eq!(Some(2), ArcStr::strong_count(&also_foobar));
 
-    let baz = unsafe { arcstr::literal_arcstr!(b"baz") };
+    let baz = arcstr::literal!("baz");
     assert_eq!(None, ArcStr::strong_count(&baz));
     assert_eq!(None, ArcStr::strong_count(&ArcStr::default()));
 }
@@ -209,22 +209,23 @@ fn test_ptr_eq() {
     assert!(ArcStr::ptr_eq(&foobar, &same_foobar));
     assert!(!ArcStr::ptr_eq(&foobar, &other_foobar));
 
-    const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = unsafe { arcstr::literal_arcstr!(b"foobar") };
+    const YET_AGAIN_A_DIFFERENT_FOOBAR: ArcStr = arcstr::literal!("foobar");
     let strange_new_foobar = YET_AGAIN_A_DIFFERENT_FOOBAR.clone();
     let wild_blue_foobar = strange_new_foobar.clone();
     assert!(ArcStr::ptr_eq(&strange_new_foobar, &wild_blue_foobar));
 }
+
 #[test]
 fn test_statics() {
-    const STATIC: ArcStr = unsafe { arcstr::literal_arcstr!(b"Electricity!") };
+    const STATIC: ArcStr = arcstr::literal!("Electricity!");
     assert!(ArcStr::is_static(&STATIC));
     assert_eq!(ArcStr::as_static(&STATIC), Some("Electricity!"));
 
     assert!(ArcStr::is_static(&ArcStr::new()));
     assert_eq!(ArcStr::as_static(&ArcStr::new()), Some(""));
     let st = {
-        // Note that they don't have to be consts, just made using `literal_arcstr!`:
-        let still_static = unsafe { arcstr::literal_arcstr!(b"Shocking!") };
+        // Note that they don't have to be consts, just made using `literal!`:
+        let still_static = { arcstr::literal!("Shocking!") };
         assert!(ArcStr::is_static(&still_static));
         assert_eq!(ArcStr::as_static(&still_static), Some("Shocking!"));
         assert_eq!(ArcStr::as_static(&still_static.clone()), Some("Shocking!"));
@@ -244,7 +245,7 @@ fn test_statics() {
 
 #[test]
 fn test_static_arcstr_include_bytes() {
-    const APACHE: ArcStr = unsafe { arcstr::literal_arcstr!(include_bytes!("../LICENSE-APACHE")) };
+    const APACHE: ArcStr = arcstr::literal!(include_str!("../LICENSE-APACHE"));
     assert!(APACHE.len() > 10000);
     assert!(APACHE.trim_start().starts_with("Apache License"));
     assert!(APACHE
@@ -306,7 +307,7 @@ fn test_froms_more() {
     assert!(matches!(cow, Some(Cow::Owned(_))));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
-    let st = unsafe { arcstr::literal_arcstr!(b"static should borrow") };
+    let st = { arcstr::literal!("static should borrow") };
     {
         let cow: Option<Cow<'_, str>> = Some(st.clone()).map(Cow::from);
         assert!(matches!(cow, Some(Cow::Borrowed(_))));


### PR DESCRIPTION
Fixes #5.

This supercedes #8, since it avoids the need to use a proc-macro or reduce the functionality. 

Additionally, it superceeds my 1.46.0 branch, since this both works on stable and should be more efficient to evaluate at compile time than a manual loop.

CC @rodrimati1992 who suggested using the union like this, whereas I had always been stumped by the "no deref" rule.