### PR TITLE
Added protection against shadowed built-in str and u8 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub mod _private {
     //
     // Anyway, this trick is courtesy of rodrimati1992 (that means you have to
     // blame them if it blows up :p).
+    #[repr(C)]
     pub union ConstPtrDeref<Arr: Copy + 'static> {
         pub p: *const u8,
         pub a: &'static Arr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,4 +103,5 @@ pub mod _private {
         pub a: &'static Arr,
     }
     pub use crate::arc_str::StaticArcStrInner;
+    pub use core::primitive::{str, u8};
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -31,15 +31,15 @@ macro_rules! literal {
     ($text:expr) => {{
         // Note: extra scope to reduce the size of what's in `$text`'s scope
         // (note that consts in macros dont have hygene the way let does).
-        const __TEXT: &str = $text;
+        const __TEXT: &$crate::__private::str = $text;
         {
-            const SI: &$crate::_private::StaticArcStrInner<[u8; __TEXT.len()]> = unsafe {
+            const SI: &$crate::_private::StaticArcStrInner<[$crate::__private::u8; __TEXT.len()]> = unsafe {
                 &$crate::_private::StaticArcStrInner {
                     len_flags: __TEXT.len() << 1,
                     count: 0,
                     // See comment for `_private::ConstPtrDeref` for what the hell's
                     // going on here.
-                    data: *$crate::_private::ConstPtrDeref::<[u8; __TEXT.len()]> {
+                    data: *$crate::_private::ConstPtrDeref::<[$crate::__private::u8; __TEXT.len()]> {
                         p: __TEXT.as_ptr(),
                     }
                     .a,
@@ -103,7 +103,7 @@ macro_rules! format {
 #[cfg(feature = "substr")]
 macro_rules! literal_substr {
     ($text:expr) => {{
-        const __S: &str = $text;
+        const __S: &$crate::__private::str = $text;
         {
             const PARENT: $crate::ArcStr = $crate::literal!(__S);
             const SUBSTR: $crate::Substr =

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -103,7 +103,7 @@ macro_rules! format {
 #[cfg(feature = "substr")]
 macro_rules! literal_substr {
     ($text:expr) => {{
-        const __S: &$crate::__private::str = $text;
+        const __S: &$crate::_private::str = $text;
         {
             const PARENT: $crate::ArcStr = $crate::literal!(__S);
             const SUBSTR: $crate::Substr =

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -31,15 +31,15 @@ macro_rules! literal {
     ($text:expr) => {{
         // Note: extra scope to reduce the size of what's in `$text`'s scope
         // (note that consts in macros dont have hygene the way let does).
-        const __TEXT: &$crate::__private::str = $text;
+        const __TEXT: &$crate::_private::str = $text;
         {
-            const SI: &$crate::_private::StaticArcStrInner<[$crate::__private::u8; __TEXT.len()]> = unsafe {
+            const SI: &$crate::_private::StaticArcStrInner<[$crate::_private::u8; __TEXT.len()]> = unsafe {
                 &$crate::_private::StaticArcStrInner {
                     len_flags: __TEXT.len() << 1,
                     count: 0,
                     // See comment for `_private::ConstPtrDeref` for what the hell's
                     // going on here.
-                    data: *$crate::_private::ConstPtrDeref::<[$crate::__private::u8; __TEXT.len()]> {
+                    data: *$crate::_private::ConstPtrDeref::<[$crate::_private::u8; __TEXT.len()]> {
                         p: __TEXT.as_ptr(),
                     }
                     .a,


### PR DESCRIPTION
This prevents safety bugs when crates have their own `u8` type for *some* reason.
Also fixed the representation attribute of the union by changing it to `#[repr(C)]`, the default is almost never what you want.