### PR TITLE
Add ArcStr::try_alloc to support fallible allocation  

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 coverage:
-  branch: main
   # Don't trigger CI failure on coverage reduction. I care about code coverage a
   # lot in this project, but I'm capable of making the decision on my own, and
   # can't run certain tests under coverage (loom's thread fuzzing stuff, for
@@ -8,6 +7,10 @@ coverage:
     project:
       default:
         informational: true
+        branches:
+          - main
     patch:
       default:
         informational: true
+        branches:
+          - main

--- a/tests/arc_str.rs
+++ b/tests/arc_str.rs
@@ -333,3 +333,9 @@ fn test_froms_more() {
     let astr2 = ArcStr::from("foobar");
     assert!(ArcStr::ptr_eq(&astr2, &ArcStr::from(&astr2)))
 }
+
+#[test]
+fn try_allocate() {
+    assert_eq!(ArcStr::try_alloc("foo").as_deref(), Some("foo"));
+    // TODO: how to test the error cases here?
+}


### PR DESCRIPTION
The name is a bit dubious — arguably it should be `try_new`. I prefer this name, as it's very clear in which case it is that failure occurs.

That said, arguably it should still return a Result type, but I don't think it matters.

In particular: I don't really think it's worth exposing the distinction between the different allocation failures, as (technically) that could be used to argue changing the size of an ThinInner header in the future is breaking (as code that only handles one error might have to handle the other).

This also tells codecov it's not a big deal if coverage drops a little (which we used to do, but I guess the format of it's configuration changed? Who the hell knows).

This is kind of needed as I'm unsure how to artificially trigger this failure (the code is straightforward enough, though). If/when we support custom allocators (if an API for this ever stabilizes) testing that case will become more straightforward, as it could be done with a mocked allocator.