### PR TITLE
Ensure argument capture works as expected in `arcstr::format!`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
           echo "CARGO=cross" >> $GITHUB_ENV
           echo "TARGET=--target ${{ matrix.target }}" >> $GITHUB_ENV
 
+      # We have some tests that make sure functionality not present in old
+      # versions behaves as expected (for example, `arcstr::format!("{foo}")`)
+      # To test this, we put them behind `#[cfg(not(msrv))]`.
+      - if: matrix.build == 'msrv'
+        run: |
+          echo "RUSTFLAGS=--cfg msrv" >> $GITHUB_ENV
+
       - name: Show command used for Cargo
         run: |
           echo "cargo command is: ${{ env.CARGO }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcstr"
-version = "1.1.3"
+version = "1.1.4"
 authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
 edition = "2018"
 description = "A better reference-counted string type, with zero-cost (allocation-free) support for string literals, and reference counted substrings."

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -53,9 +53,6 @@ macro_rules! literal {
 
 /// Conceptually equivalent to `ArcStr::from(format!("...", args...))`.
 ///
-/// Currently, the only difference here is that when used with no formatting
-/// args, this behaves equivalently to [`arcstr::literal!`](crate::literal).
-///
 /// In the future, this will be implemented in such a way to avoid an additional
 /// string copy which is required by the `from` operation.
 ///
@@ -67,12 +64,8 @@ macro_rules! literal {
 /// ```
 #[macro_export]
 macro_rules! format {
-    ($text:expr $(,)?) => {
-        // prevent use as const, but keep cheap.
-        $crate::ArcStr::from($crate::literal!($text))
-    };
-    ($text:expr, $($toks:tt)+) => {
-        $crate::ArcStr::from($crate::alloc::fmt::format($crate::core::format_args!($text, $($toks)+)))
+    ($($toks:tt)*) => {
+        $crate::ArcStr::from($crate::alloc::fmt::format($crate::core::format_args!($($toks)*)))
     };
 }
 
@@ -133,6 +126,12 @@ mod test {
             assert_eq!(test, "foo");
             let test2 = crate::format!("foo {}", 123);
             assert_eq!(test2, "foo 123");
+            #[cfg(not(msrv))]
+            {
+                let foo = "abc";
+                let test3 = crate::format!("foo {foo}");
+                assert_eq!(test3, "foo abc");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #37.