### PR TITLE
Appease new clippy

### DIFF
--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -1036,6 +1036,7 @@ impl Eq for ArcStr {}
 
 macro_rules! impl_peq {
     (@one $a:ty, $b:ty) => {
+        #[allow(clippy::extra_unused_lifetimes)]
         impl<'a> PartialEq<$b> for $a {
             #[inline]
             fn eq(&self, s: &$b) -> bool {
@@ -1061,6 +1062,8 @@ impl_peq! {
     (ArcStr, Box<str>),
     (ArcStr, alloc::sync::Arc<str>),
     (ArcStr, alloc::rc::Rc<str>),
+    (ArcStr, alloc::sync::Arc<String>),
+    (ArcStr, alloc::rc::Rc<String>),
 }
 
 impl PartialOrd for ArcStr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //! It's an open TODO to update this "feature tour" to include `Substr`.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
+#![allow(unknown_lints)]
 
 #[doc(hidden)]
 pub extern crate alloc;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -18,8 +18,7 @@
 /// assert_eq!("Wow!", arcstr::literal!("Wow!"));
 /// ```
 ///
-/// Another motivating use case is bundled files (eventually this will improve
-/// when `arcstr::Substr` is implemented):
+/// Another motivating use case is bundled files:
 ///
 /// ```rust,ignore
 /// use arcstr::ArcStr;
@@ -28,7 +27,7 @@
 /// ```
 #[macro_export]
 macro_rules! literal {
-    ($text:expr) => {{
+    ($text:expr $(,)?) => {{
         // Note: extra scope to reduce the size of what's in `$text`'s scope
         // (note that consts in macros dont have hygene the way let does).
         const __TEXT: &$crate::_private::str = $text;
@@ -95,7 +94,7 @@ macro_rules! format {
 #[macro_export]
 #[cfg(feature = "substr")]
 macro_rules! literal_substr {
-    ($text:expr) => {{
+    ($text:expr $(,)?) => {{
         const __S: &$crate::_private::str = $text;
         {
             const PARENT: $crate::ArcStr = $crate::literal!(__S);

--- a/src/substr.rs
+++ b/src/substr.rs
@@ -58,6 +58,7 @@ pub struct Substr(ArcStr, Idx, Idx);
 
 #[inline]
 #[cfg(all(target_pointer_width = "64", not(feature = "substr-usize-indices")))]
+#[allow(clippy::let_unit_value)]
 const fn to_idx_const(i: usize) -> Idx {
     const DUMMY: [(); 1] = [()];
     let _ = DUMMY[i >> 32];
@@ -700,6 +701,7 @@ impl<'a> From<Substr> for alloc::borrow::Cow<'a, str> {
 
 macro_rules! impl_peq {
     (@one $a:ty, $b:ty) => {
+        #[allow(clippy::extra_unused_lifetimes)]
         impl<'a> PartialEq<$b> for $a {
             #[inline]
             fn eq(&self, s: &$b) -> bool {


### PR DESCRIPTION
This also adds some new PartialEq impls and makes some macros accept an optional trailing comma.