### PR TITLE
Support creating static `ArcStr`'s at runtime (leaking them)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           - build: ppc64
             os: ubuntu-latest
             rust: stable
-            target: powerpc64-unknown-linux-gnuabi64
+            target: powerpc64-unknown-linux-gnu
           # Requested by a user not sure if it adds anything we aren't already
           # testing but it's easy enough so *shrug*.
           - build: riscv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
           - nightly
           - arm32
           - arm64
-          - mips32
-          - mips64
+          - ppc32
+          - ppc64
         include:
           - build: linux
             os: ubuntu-latest
@@ -86,16 +86,16 @@ jobs:
             os: ubuntu-latest
             rust: stable
             target: aarch64-unknown-linux-gnu
-          # Mips is big endian. Nothing currently in here cares... but will if I
+          # PPC is big endian. Nothing currently in here cares... but will if I
           # ever get around to that `key` stuff.
-          - build: mips32
+          - build: ppc32
             os: ubuntu-latest
             rust: stable
-            target: mips-unknown-linux-gnu
-          - build: mips64
+            target: powerpc-unknown-linux-gnu
+          - build: ppc64
             os: ubuntu-latest
             rust: stable
-            target: mips64-unknown-linux-gnuabi64
+            target: powerpc64-unknown-linux-gnuabi64
           # Requested by a user not sure if it adds anything we aren't already
           # testing but it's easy enough so *shrug*.
           - build: riscv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,9 @@ jobs:
           - build: win32-gnu
             os: windows-2019
             rust: stable-i686-gnu
-          # TODO: re-enable this I guess. I get inscrutable errors like
-          # `error reading from the zlib stream; class=Zlib (5)` in CI
-          # that don't repro locally, and I'm tired of getting an email
-          # about this every day.
-          #
-          # - build: msrv
-          #   os: ubuntu-latest
-          #   rust: "1.43.0"
+          - build: msrv
+            os: ubuntu-latest
+            rust: "1.57.0"
           - build: beta
             os: ubuntu-latest
             rust: beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - run: cargo miri test --features="std serde substr"
       - run: cargo miri test
 
-  cargo-clippy:
+  cargo-check:
     name: Lint
     runs-on: ubuntu-latest
     env:
@@ -165,12 +165,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v2
-        with:
-          components: clippy
-      - run: cargo clippy --workspace --all-targets --verbose
-      - run: cargo clippy --workspace --all-targets --verbose --all-features
-      - run: cargo clippy --workspace --all-targets --verbose --features="serde std substr"
-      - run: cargo clippy --workspace --all-targets --verbose --no-default-features
+      - run: cargo check --workspace --all-targets --verbose
+      - run: cargo check --workspace --all-targets --verbose --all-features
+      - run: cargo check --workspace --all-targets --verbose --features="serde std substr"
+      - run: cargo check --workspace --all-targets --verbose --no-default-features
 
   # Ensure patch is formatted.
   fmt:
@@ -180,19 +178,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v2
       - run: cargo fmt --all -- --check
-
-  # Check doc reference links are all valid.
-  doc:
-    name: Doc check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          minimal: true
-          override: true
-      - run: cargo doc --features="serde std substr"
 
   sanitizers:
     name: Test sanitizer ${{ matrix.sanitizer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
-  schedule:
-    - cron: "00 01 * * *"
 
 env:
   RUST_BACKTRACE: short
@@ -108,12 +104,10 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
+          rust-version: ${{ matrix.rust }}
 
       - uses: taiki-e/install-action@cross
         if: matrix.target != ''
@@ -145,27 +139,20 @@ jobs:
     env:
       RUSTFLAGS: --cfg loom -Dwarnings
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
       - run: cargo test --all-features --lib
       - run: cargo test --no-default-features --lib
 
   miri:
     name: Miri
     runs-on: ubuntu-latest
-    env:
-      MIRIFLAGS: -Zmiri-tag-raw-pointers
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
-          toolchain: nightly
+          rust-version: nightly
           components: miri, rust-src
-          override: true
       - run: cargo miri test --all-features
       - run: cargo miri test --features="std serde substr"
       - run: cargo miri test
@@ -176,13 +163,10 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
         with:
-          toolchain: stable
           components: clippy
-          minimal: true
-          override: true
       - run: cargo clippy --workspace --all-targets --verbose
       - run: cargo clippy --workspace --all-targets --verbose --all-features
       - run: cargo clippy --workspace --all-targets --verbose --features="serde std substr"
@@ -193,13 +177,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-          minimal: true
-          override: true
+      - uses: actions/checkout@v4
+      - uses: hecrj/setup-rust-action@v2
       - run: cargo fmt --all -- --check
 
   # Check doc reference links are all valid.
@@ -207,7 +186,7 @@ jobs:
     name: Doc check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -233,7 +212,7 @@ jobs:
             extra_rustflags: "-Zsanitizer-memory-track-origins"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -251,17 +230,15 @@ jobs:
           cargo -Zbuild-std test --target=x86_64-unknown-linux-gnu --all-features
           cargo -Zbuild-std test --target=x86_64-unknown-linux-gnu --no-default-features
 
-  codecov:
-    name: Generate code coverage
+  codecov-tarpaulin:
+    name: coverage
     runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
     steps:
-      - uses: actions/checkout@v3
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - run: cargo tarpaulin --verbose --doc --all-features --all-targets --engine llvm --out xml
+      - uses: codecov/codecov-action@v4
         with:
-          toolchain: stable
-          override: true
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "arcstr"
 version = "1.1.5"
+rust-version = "1.57.0"
 authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
 edition = "2021"
 description = "A better reference-counted string type, with zero-cost (allocation-free) support for string literals, and reference counted substrings."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arcstr"
 version = "1.1.5"
 authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A better reference-counted string type, with zero-cost (allocation-free) support for string literals, and reference counted substrings."
 license = "Apache-2.0 OR MIT OR Zlib"
 readme = "README.md"
@@ -29,7 +29,6 @@ serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }
-memoffset = "0.9"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }
-memoffset = "0.6"
+memoffset = "0.9"
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = "0.5.6"
+loom = "0.7.1"
 
 [package.metadata.docs.rs]
 features = ["std", "substr"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/thomcc/arcstr/branch/main/graph/badge.svg)](https://codecov.io/gh/thomcc/arcstr)
 [![Docs](https://docs.rs/arcstr/badge.svg)](https://docs.rs/arcstr)
 [![Latest Version](https://img.shields.io/crates/v/arcstr.svg)](https://crates.io/crates/arcstr)
-![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.43-blue.svg)
+![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.57-blue.svg)
 
 This crate defines `ArcStr`, a reference counted string type. It's essentially trying to be a better `Arc<str>` or `Arc<String>`, at least for most use cases.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+// I hate that this is needed...
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(loom)");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 // I hate that this is needed...
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(loom)");
+    println!("cargo::rustc-check-cfg=cfg(loom, msrv)");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-// I hate that this is needed...
-fn main() {
-    println!("cargo::rustc-check-cfg=cfg(loom, msrv)");
-}

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -1366,45 +1366,46 @@ impl core::str::FromStr for ArcStr {
 }
 
 #[cfg(test)]
+#[cfg(not(msrv))] // core::mem::offset_of! isn't stable in our MSRV
 mod test {
     use super::*;
 
     fn sasi_layout_check<Buf>() {
         assert!(align_of::<StaticArcStrInner<Buf>>() >= 8);
         assert_eq!(
-            memoffset::offset_of!(StaticArcStrInner<Buf>, count_flag),
+            core::mem::offset_of!(StaticArcStrInner<Buf>, count_flag),
             OFFSET_COUNTFLAGS
         );
         assert_eq!(
-            memoffset::offset_of!(StaticArcStrInner<Buf>, len_flag),
+            core::mem::offset_of!(StaticArcStrInner<Buf>, len_flag),
             OFFSET_LENFLAGS
         );
         assert_eq!(
-            memoffset::offset_of!(StaticArcStrInner<Buf>, data),
+            core::mem::offset_of!(StaticArcStrInner<Buf>, data),
             OFFSET_DATA
         );
         assert_eq!(
-            memoffset::offset_of!(ThinInner, count_flag),
-            memoffset::offset_of!(StaticArcStrInner::<Buf>, count_flag),
+            core::mem::offset_of!(ThinInner, count_flag),
+            core::mem::offset_of!(StaticArcStrInner::<Buf>, count_flag),
         );
         assert_eq!(
-            memoffset::offset_of!(ThinInner, len_flag),
-            memoffset::offset_of!(StaticArcStrInner::<Buf>, len_flag),
+            core::mem::offset_of!(ThinInner, len_flag),
+            core::mem::offset_of!(StaticArcStrInner::<Buf>, len_flag),
         );
         assert_eq!(
-            memoffset::offset_of!(ThinInner, data),
-            memoffset::offset_of!(StaticArcStrInner::<Buf>, data),
+            core::mem::offset_of!(ThinInner, data),
+            core::mem::offset_of!(StaticArcStrInner::<Buf>, data),
         );
     }
 
     #[test]
     fn verify_type_pun_offsets_sasi_big_bufs() {
         assert_eq!(
-            memoffset::offset_of!(ThinInner, count_flag),
+            core::mem::offset_of!(ThinInner, count_flag),
             OFFSET_COUNTFLAGS,
         );
-        assert_eq!(memoffset::offset_of!(ThinInner, len_flag), OFFSET_LENFLAGS);
-        assert_eq!(memoffset::offset_of!(ThinInner, data), OFFSET_DATA);
+        assert_eq!(core::mem::offset_of!(ThinInner, len_flag), OFFSET_LENFLAGS);
+        assert_eq!(core::mem::offset_of!(ThinInner, data), OFFSET_DATA);
 
         assert!(align_of::<ThinInner>() >= 8);
 

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -392,7 +392,7 @@ impl ArcStr {
     /// `Self::has_static_lenflag`)
     #[inline]
     unsafe fn load_count_flag_raw(this: &Self, ord_if_needed: Ordering) -> PackedFlagUint {
-        PackedFlagUint::from_encoded(unsafe { (*this.0.as_ptr()).count_flag.load(ord_if_needed) })
+        PackedFlagUint::from_encoded((*this.0.as_ptr()).count_flag.load(ord_if_needed))
     }
 
     #[inline]
@@ -447,7 +447,7 @@ impl ArcStr {
 
     #[inline]
     unsafe fn to_static_unchecked(this: &Self) -> &'static str {
-        unsafe { &*Self::str_ptr(this) }
+        &*Self::str_ptr(this)
     }
 
     #[inline]

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -863,7 +863,7 @@ impl Clone for ArcStr {
         Self(self.0)
     }
 }
-const RC_MAX: usize = (PackedFlagUint::UINT_PART_MAX / 2) as usize;
+const RC_MAX: usize = PackedFlagUint::UINT_PART_MAX / 2;
 
 impl Drop for ArcStr {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
+// for `cfg(loom)` and such -- I don't want to add a build.rs for this.
+#![allow(unexpected_cfgs)]
 
 #[doc(hidden)]
 pub extern crate alloc;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -34,14 +34,14 @@ macro_rules! literal {
         {
             const SI: &$crate::_private::StaticArcStrInner<[$crate::_private::u8; __TEXT.len()]> = unsafe {
                 &$crate::_private::StaticArcStrInner {
-                    len_flags: __TEXT.len() << 1,
-                    count: 0,
+                    len_flag: match $crate::_private::StaticArcStrInner::<[$crate::_private::u8; __TEXT.len()]>::encode_len(__TEXT.len()) {
+                        Some(len) => len,
+                        None => $crate::core::panic!("impossibly long length")
+                    },
+                    count_flag: $crate::_private::StaticArcStrInner::<[$crate::_private::u8; __TEXT.len()]>::STATIC_COUNT_VALUE,
                     // See comment for `_private::ConstPtrDeref` for what the hell's
                     // going on here.
-                    data: *$crate::_private::ConstPtrDeref::<[$crate::_private::u8; __TEXT.len()]> {
-                        p: __TEXT.as_ptr(),
-                    }
-                    .a,
+                    data: __TEXT.as_ptr().cast::<[$crate::_private::u8; __TEXT.len()]>().read(),
                 }
             };
             const S: $crate::ArcStr = unsafe { $crate::ArcStr::_private_new_from_static_data(SI) };

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -32,6 +32,7 @@ macro_rules! literal {
         // (note that consts in macros dont have hygene the way let does).
         const __TEXT: &$crate::_private::str = $text;
         {
+            #[allow(clippy::declare_interior_mutable_const)]
             const SI: &$crate::_private::StaticArcStrInner<[$crate::_private::u8; __TEXT.len()]> = unsafe {
                 &$crate::_private::StaticArcStrInner {
                     len_flag: match $crate::_private::StaticArcStrInner::<[$crate::_private::u8; __TEXT.len()]>::encode_len(__TEXT.len()) {
@@ -44,6 +45,7 @@ macro_rules! literal {
                     data: __TEXT.as_ptr().cast::<[$crate::_private::u8; __TEXT.len()]>().read(),
                 }
             };
+            #[allow(clippy::declare_interior_mutable_const)]
             const S: $crate::ArcStr = unsafe { $crate::ArcStr::_private_new_from_static_data(SI) };
             S
         }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -42,7 +42,11 @@ macro_rules! literal {
                     count_flag: $crate::_private::StaticArcStrInner::<[$crate::_private::u8; __TEXT.len()]>::STATIC_COUNT_VALUE,
                     // See comment for `_private::ConstPtrDeref` for what the hell's
                     // going on here.
-                    data: __TEXT.as_ptr().cast::<[$crate::_private::u8; __TEXT.len()]>().read(),
+                    data: *$crate::_private::ConstPtrDeref::<[$crate::_private::u8; __TEXT.len()]> {
+                        p: __TEXT.as_ptr(),
+                    }
+                    .a,
+                    // data: __TEXT.as_ptr().cast::<[$crate::_private::u8; __TEXT.len()]>().read(),
                 }
             };
             #[allow(clippy::declare_interior_mutable_const)]

--- a/tests/arc_str.rs
+++ b/tests/arc_str.rs
@@ -307,22 +307,22 @@ fn test_froms_more() {
     let cow: Cow<'_, str> = Owned("abcd".into());
     assert_eq!(ArcStr::from(cow), "abcd");
 
-    let cow: Option<Cow<'_, str>> = Some(&arc).map(Cow::from);
+    let cow: Option<Cow<'_, str>> = Some(Cow::from(&arc));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
-    let cow: Option<Cow<'_, str>> = Some(arc).map(Cow::from);
+    let cow: Option<Cow<'_, str>> = Some(Cow::from(arc));
     assert!(matches!(cow, Some(Cow::Owned(_))));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
     let st = { arcstr::literal!("static should borrow") };
     {
-        let cow: Option<Cow<'_, str>> = Some(st.clone()).map(Cow::from);
+        let cow: Option<Cow<'_, str>> = Some(Cow::from(st.clone()));
         assert!(matches!(cow, Some(Cow::Borrowed(_))));
         assert_eq!(cow.as_deref(), Some("static should borrow"));
     }
     // works with any lifetime
     {
-        let cow: Option<Cow<'static, str>> = Some(st.clone()).map(Cow::from);
+        let cow: Option<Cow<'static, str>> = Some(Cow::from(st.clone()));
         assert!(matches!(cow, Some(Cow::Borrowed(_))));
         assert_eq!(cow.as_deref(), Some("static should borrow"));
     }

--- a/tests/substr.rs
+++ b/tests/substr.rs
@@ -269,23 +269,23 @@ fn test_cow() {
     let cow: Cow<'_, str> = Owned("abcd".into());
     assert_eq!(Substr::from(cow), "abcd");
     let sub = ArcStr::from("XXasdfYY").substr(2..6);
-    let cow: Option<Cow<'_, str>> = Some(&sub).map(Cow::from);
+    let cow: Option<Cow<'_, str>> = Some(Cow::from(&sub));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
-    let cow: Option<Cow<'_, str>> = Some(sub).map(Cow::from);
+    let cow: Option<Cow<'_, str>> = Some(Cow::from(sub));
     assert!(matches!(cow, Some(Cow::Owned(_))));
     assert_eq!(cow.as_deref(), Some("asdf"));
 
     let st = { arcstr::literal!("_static should borrow_") };
     let ss = st.substr(1..st.len() - 1);
     {
-        let cow: Option<Cow<'_, str>> = Some(ss.clone()).map(Cow::from);
+        let cow: Option<Cow<'_, str>> = Some(Cow::from(ss.clone()));
         assert!(matches!(cow, Some(Cow::Borrowed(_))));
         assert_eq!(cow.as_deref(), Some("static should borrow"));
     }
     // works with any lifetime
     {
-        let cow: Option<Cow<'static, str>> = Some(ss.clone()).map(Cow::from);
+        let cow: Option<Cow<'static, str>> = Some(Cow::from(ss.clone()));
         assert!(matches!(cow, Some(Cow::Borrowed(_))));
         assert_eq!(cow.as_deref(), Some("static should borrow"));
     }


### PR DESCRIPTION
I wrote this a while ago, then didn't need it, but it may be useful to others.

The main drawback is that it adds a branch to refcount manipulation, but that should be a wash (the function is already doing atomic RMWs, which are likely more costly than a the branching most of the time).

On the positive side, it makes it so we no longer need to abort on refcount overflow -- we can simply transition the string to static (leak it).

I've also updated some deps and may do a bit of other cleanup while I'm here.

EDIT: this is now mostly cleanup.