### PR TITLE
Use `check-cfg` lint config instead of allowing `unexpected_cfgs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = ["substr"]
 substr = []
 substr-usize-indices = ["substr"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom, msrv)'] }
+
 [dependencies]
 serde = { version = "1", default-features = false, optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
-// for `cfg(loom)` and such -- I don't want to add a build.rs for this.
-#![allow(unexpected_cfgs)]
 
 #[doc(hidden)]
 pub extern crate alloc;


### PR DESCRIPTION
With the release of rust-lang/cargo#13913 (in nightly-2024-05-19), Cargo has now gain the ability to declare `--check-cfg` args directly inside the `[lints]` table with [`[lints.rust.unexpected_cfgs.check-cfg]`](https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table)[^1]:

`Cargo.toml`:
```toml
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom, msrv)'] }
```

This PR therefore just replace the global `#![allow(unexpected_cfgs)]` with the above.

[^1]: take effect on Rust 1.80 (current nightly), is ignored on Rust 1.79 (current beta), and produce an unused warning below