### PR TITLE
Support pyo3's conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ std = []
 default = ["substr"]
 substr = []
 substr-usize-indices = ["substr"]
+pyo3 = ["dep:pyo3", "dep:pyo3-stub-gen"]
 
 [dependencies]
 serde = { version = "1", default-features = false, optional = true }
 pyo3 = { version = "0.23", default-features = false, optional = true }
+pyo3-stub-gen = { version = "0.6.2", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ substr-usize-indices = ["substr"]
 
 [dependencies]
 serde = { version = "1", default-features = false, optional = true }
+pyo3 = { version = "0.23", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The following cargo features are available. Only `substr` is on by default curre
 
     Without this, if you use `Substr` and an index would overflow a `u32` we unceremoniously panic.
 
+- `pyo3` (off by default): enable pyo3 conversion of `ArcStr`.
+
 ## Use of `unsafe` and testing strategy
 
 While this crate does contain a decent amount of unsafe code, we justify this in the following ways:

--- a/src/impl_pyo3.rs
+++ b/src/impl_pyo3.rs
@@ -37,6 +37,23 @@ impl<'py> FromPyObject<'py> for ArcStr {
     }
 }
 
+impl pyo3_stub_gen::PyStubType for ArcStr {
+    #[inline]
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "str".to_owned(),
+            import: Default::default(),
+        }
+    }
+    #[inline]
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "str".to_owned(),
+            import: Default::default(),
+        }
+    }
+}
+
 // Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#188-201
 #[cfg(feature = "substr")]
 impl<'py> IntoPyObject<'py> for Substr {
@@ -69,5 +86,23 @@ impl<'py> FromPyObject<'py> for Substr {
     #[inline]
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         obj.downcast::<PyString>()?.to_cow().map(Substr::from)
+    }
+}
+
+#[cfg(feature = "substr")]
+impl pyo3_stub_gen::PyStubType for Substr {
+    #[inline]
+    fn type_input() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "str".to_owned(),
+            import: Default::default(),
+        }
+    }
+    #[inline]
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo {
+            name: "str".to_owned(),
+            import: Default::default(),
+        }
     }
 }

--- a/src/impl_pyo3.rs
+++ b/src/impl_pyo3.rs
@@ -41,7 +41,7 @@ impl<'py> FromPyObject<'py> for ArcStr {
 impl PyStubType for ArcStr {
     #[inline]
     fn type_output() -> TypeInfo {
-        String::type_output()
+        PyString::type_output()
     }
 }
 
@@ -84,6 +84,6 @@ impl<'py> FromPyObject<'py> for Substr {
 impl PyStubType for Substr {
     #[inline]
     fn type_output() -> TypeInfo {
-        String::type_output()
+        PyString::type_output()
     }
 }

--- a/src/impl_pyo3.rs
+++ b/src/impl_pyo3.rs
@@ -1,0 +1,73 @@
+use super::ArcStr;
+#[cfg(feature = "substr")]
+use super::Substr;
+
+use core::convert::Infallible;
+use pyo3::{prelude::*, types::PyString};
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#188-201
+impl<'py> IntoPyObject<'py> for ArcStr {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.as_str()))
+    }
+}
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#211-225
+impl<'py> IntoPyObject<'py> for &ArcStr {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.as_str()))
+    }
+}
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#252-261
+impl<'py> FromPyObject<'py> for ArcStr {
+    #[inline]
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        obj.downcast::<PyString>()?.to_cow().map(ArcStr::from)
+    }
+}
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#188-201
+#[cfg(feature = "substr")]
+impl<'py> IntoPyObject<'py> for Substr {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.as_str()))
+    }
+}
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#211-225
+#[cfg(feature = "substr")]
+impl<'py> IntoPyObject<'py> for &Substr {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self.as_str()))
+    }
+}
+
+// Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#252-261
+#[cfg(feature = "substr")]
+impl<'py> FromPyObject<'py> for Substr {
+    #[inline]
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        obj.downcast::<PyString>()?.to_cow().map(Substr::from)
+    }
+}

--- a/src/impl_pyo3.rs
+++ b/src/impl_pyo3.rs
@@ -1,7 +1,7 @@
+use super::alloc::string::ToString;
 use super::ArcStr;
 #[cfg(feature = "substr")]
 use super::Substr;
-
 use core::convert::Infallible;
 use pyo3::{prelude::*, types::PyString};
 
@@ -41,14 +41,14 @@ impl pyo3_stub_gen::PyStubType for ArcStr {
     #[inline]
     fn type_input() -> pyo3_stub_gen::TypeInfo {
         pyo3_stub_gen::TypeInfo {
-            name: "str".to_owned(),
+            name: "str".to_string(),
             import: Default::default(),
         }
     }
     #[inline]
     fn type_output() -> pyo3_stub_gen::TypeInfo {
         pyo3_stub_gen::TypeInfo {
-            name: "str".to_owned(),
+            name: "str".to_string(),
             import: Default::default(),
         }
     }
@@ -94,14 +94,14 @@ impl pyo3_stub_gen::PyStubType for Substr {
     #[inline]
     fn type_input() -> pyo3_stub_gen::TypeInfo {
         pyo3_stub_gen::TypeInfo {
-            name: "str".to_owned(),
+            name: "str".to_string(),
             import: Default::default(),
         }
     }
     #[inline]
     fn type_output() -> pyo3_stub_gen::TypeInfo {
         pyo3_stub_gen::TypeInfo {
-            name: "str".to_owned(),
+            name: "str".to_string(),
             import: Default::default(),
         }
     }

--- a/src/impl_pyo3.rs
+++ b/src/impl_pyo3.rs
@@ -1,9 +1,10 @@
-use super::alloc::string::ToString;
 use super::ArcStr;
 #[cfg(feature = "substr")]
 use super::Substr;
+
 use core::convert::Infallible;
 use pyo3::{prelude::*, types::PyString};
+use pyo3_stub_gen::{PyStubType, TypeInfo};
 
 // Same to https://docs.rs/pyo3/0.23.3/src/pyo3/conversions/std/string.rs.html#188-201
 impl<'py> IntoPyObject<'py> for ArcStr {
@@ -37,20 +38,10 @@ impl<'py> FromPyObject<'py> for ArcStr {
     }
 }
 
-impl pyo3_stub_gen::PyStubType for ArcStr {
+impl PyStubType for ArcStr {
     #[inline]
-    fn type_input() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo {
-            name: "str".to_string(),
-            import: Default::default(),
-        }
-    }
-    #[inline]
-    fn type_output() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo {
-            name: "str".to_string(),
-            import: Default::default(),
-        }
+    fn type_output() -> TypeInfo {
+        String::type_output()
     }
 }
 
@@ -90,19 +81,9 @@ impl<'py> FromPyObject<'py> for Substr {
 }
 
 #[cfg(feature = "substr")]
-impl pyo3_stub_gen::PyStubType for Substr {
+impl PyStubType for Substr {
     #[inline]
-    fn type_input() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo {
-            name: "str".to_string(),
-            import: Default::default(),
-        }
-    }
-    #[inline]
-    fn type_output() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo {
-            name: "str".to_string(),
-            import: Default::default(),
-        }
+    fn type_output() -> TypeInfo {
+        String::type_output()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub use core;
 #[macro_use]
 mod mac;
 mod arc_str;
+#[cfg(feature = "pyo3")]
+mod impl_pyo3;
 #[cfg(feature = "serde")]
 mod impl_serde;
 pub use arc_str::ArcStr;


### PR DESCRIPTION
Happy New Year!
Here I want to introduce the impl of [`pyo3`](https://crates.io/crates/pyo3)'s conversion (`IntoPyObject`/`FromPyObject`) for `ArcStr`/`Substr`, so that we can easily use `ArcStr` in Python applications.
And that is feature-controlled like `serdes` does.
Hope you like that :)