### PR TITLE
use portable-atomic & exclude alloc::sync::Arc where it is not available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ homepage = "https://github.com/thomcc/arcstr"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [features]
-std = []
+std = ["portable-atomic/std"]
 default = ["substr"]
 substr = []
 substr-usize-indices = ["substr"]
 
 [dependencies]
+portable-atomic = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/arc_str.rs
+++ b/src/arc_str.rs
@@ -9,10 +9,10 @@
 use core::alloc::Layout;
 use core::mem::{align_of, size_of, MaybeUninit};
 use core::ptr::NonNull;
-#[cfg(not(all(loom, test)))]
-pub(crate) use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(all(loom, test))]
 pub(crate) use loom::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(not(all(loom, test)))]
+pub(crate) use portable_atomic::{AtomicUsize, Ordering};
 
 #[cfg(feature = "substr")]
 use crate::Substr;
@@ -1378,6 +1378,7 @@ impl From<ArcStr> for alloc::rc::Rc<str> {
         s.as_str().into()
     }
 }
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<ArcStr> for alloc::sync::Arc<str> {
     #[inline]
     fn from(s: ArcStr) -> Self {
@@ -1390,6 +1391,7 @@ impl From<alloc::rc::Rc<str>> for ArcStr {
         Self::from(&*s)
     }
 }
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<alloc::sync::Arc<str>> for ArcStr {
     #[inline]
     fn from(s: alloc::sync::Arc<str>) -> Self {
@@ -1480,6 +1482,7 @@ macro_rules! impl_peq {
     )+};
 }
 
+#[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl_peq! {
     (ArcStr, str),
     (ArcStr, &'a str),
@@ -1489,6 +1492,17 @@ impl_peq! {
     (ArcStr, alloc::sync::Arc<str>),
     (ArcStr, alloc::rc::Rc<str>),
     (ArcStr, alloc::sync::Arc<String>),
+    (ArcStr, alloc::rc::Rc<String>),
+}
+
+#[cfg(not(all(not(no_rc), not(no_sync), target_has_atomic = "ptr")))]
+impl_peq! {
+    (ArcStr, str),
+    (ArcStr, &'a str),
+    (ArcStr, String),
+    (ArcStr, Cow<'a, str>),
+    (ArcStr, Box<str>),
+    (ArcStr, alloc::rc::Rc<str>),
     (ArcStr, alloc::rc::Rc<String>),
 }
 


### PR DESCRIPTION
I added the conditional compilations to exclude the implementations for 'alloc::sync::Arc<T>' for embedded targets where this Arc is not available (e.g. thumbv6m-none-eabi & riscv32imac-unknown-none-elf)

I also changed to use the crate 'portable-atomic' for atomics,  which allows to use 'arcstr' in hopefully all the embedded platforms supported by embassy.

I tested the compile for all the targets and verified proper execution on old pi pico and some other MCU's.

Closes #70